### PR TITLE
#164797135 Integrate travisCI with readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ coverage
 .coveralls.yml
 
 # nyc test coverage
-.nyc_output
+.nyc_output/
 
 # Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "stable"
+
+after_success:
+  - npm run coverage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Authors Haven - A Social platform for the creative at heart.
 =======
 
 ## Badges
+[![Build Status](https://travis-ci.com/andela/zinnia-ah-backend.svg?branch=develop)](https://travis-ci.com/andela/zinnia-ah-backend)
 [![Coverage Status](https://coveralls.io/repos/github/andela/zinnia-ah-backend/badge.svg?branch=develop)](https://coveralls.io/github/andela/zinnia-ah-backend?branch=develop)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 

--- a/package.json
+++ b/package.json
@@ -3,12 +3,24 @@
   "version": "1.0.0",
   "description": "A Social platform for the creative at heart",
   "main": "index.js",
+  "nyc": {
+    "require": [
+      "@babel/register"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "sourceMap": false,
+    "instrument": false
+  },
   "scripts": {
     "start": "node build/server.js",
     "start:dev": "nodemon --exec babel-node src/server.js",
-    "test": "NODE_ENV=test mocha src/tests/**/**.test.js --require @babel/register --exit",
+    "test": "NODE_ENV=test nyc mocha src/tests/**/**.test.js --require @babel/register --exit",
     "test:watch": "NODE_ENV=test mocha src/tests/**/**.test.js --watch",
-    "build": "rm -rf build && babel src -d build"
+    "build": "rm -rf build && babel src -d build",
+    "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "author": "Andela Simulations Programme",
   "license": "MIT",


### PR DESCRIPTION
#### What does this PR do?
Have Travis CI integrate to the AH-backend application

#### Description of Task to be completed?
Have Travis badge show on the READme.md file

#### How should this be manually tested?
Visit the repo at https://github.com/andela/zinnia-ah-backend/
Scroll down and a Travis badge should be showing at the top of the README document

#### Any background context you want to provide?
For automated testing to support the agile development of the application, we are integrating Travis a continuous Integration tool.

#### What are the relevant pivotal tracker stories?
#164797135 Integrate TravisCI with readme badge

#### Screenshots (if appropriate)
<img width="987" alt="Screen Shot 2019-03-26 at 11 43 30 AM" src="https://user-images.githubusercontent.com/41264503/54991091-7a8cbb00-4fbc-11e9-965f-ee1938c5bff2.png">


#### Questions:
None
