### PR TITLE
#165016729 fixed hound eslint error

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+.sequelizerc
+app.json
+.babelrc

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,4 @@
-module.exports = {
+{
   "root": true,
   "extends": "airbnb-base",
   "env": {
@@ -14,7 +14,7 @@ module.exports = {
     "no-param-reassign": 0,
     "comma-dangle": 0,
     "curly": ["error", "multi-line"],
-    "import/no-unresolved": [2, { commonjs: true }],
+    "import/no-unresolved": [2, { "commonjs": true }],
     "no-shadow": ["error", { "allow": ["req", "res", "err"] }],
     "valid-jsdoc": ["error", {
       "requireReturn": true,
@@ -30,4 +30,4 @@ module.exports = {
         }
     }]
   }
-};
+}

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,4 @@
 eslint: 
   enabled: true
-  config_file: .eslintrc.js
+  config_file: .eslintrc
   ignore_file: .eslintignore


### PR DESCRIPTION
#### What does this PR do?
 This PR fixes the Hound eslint invalid file error.

#### Description of Task to be completed?
none
#### How should this be manually tested?
Hound should no longer flag an Error about invalid eslint file type.

#### Any background context you want to provide?
Hound has issues parsing .eslintrc.js file type. Hound only parse *YAML* and *JSON* file.
Hound expects eslint configuration should be either of the two.

#### What are the relevant pivotal tracker stories? (if applicable)
#165016729

#### Screenshots

<img width="1167" alt="Screenshot 2019-04-01 at 10 42 18 AM" src="https://user-images.githubusercontent.com/3631446/55318713-507b4300-546b-11e9-8856-d5a66270ab69.png">
