### PR TITLE
#165052046 eslintignore documentation folder path

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 .sequelizerc
 app.json
 .babelrc
+/doc


### PR DESCRIPTION
#### What does this PR do?
 - added the documentation folder path to the *.eslintignore* file
 - passing the hound-bot test.

#### How should this be manually tested?
 - `PRs raised should not flag any error from Hound`

#### Any background context you want to provide?
 - Hound was configured to flag *es5* code. and the swagger documentation was written in es5.

#### What are the relevant pivotal tracker stories?(if applicable)
#165052046