### PR TITLE
#165441913 Attach user's articles and following stats to user profile

### DIFF
--- a/src/routes/controllers/users.controller.js
+++ b/src/routes/controllers/users.controller.js
@@ -108,7 +108,7 @@ export const updateUserProfile = async (req, res) => {
     return successResponse(
       res,
       200,
-      'Your profile has been updated succesfully',
+      'Your profile has been updated successfully',
       dataValues,
     );
   } catch (err) {

--- a/src/routes/controllers/users.controller.js
+++ b/src/routes/controllers/users.controller.js
@@ -40,13 +40,41 @@ export async function getAuthorProfile(req, res) {
       where: {
         username,
       },
+      include: {
+        model: Article,
+        as: 'publications',
+      },
     });
     if (!authorProfile) {
       return errorResponse(res, 404, 'Author not found');
     }
-    return successResponse(res, 200, 'Get profile request successful', {
-      authorProfile,
-    });
+
+    const fullProfile = authorProfile.toJSON();
+    fullProfile.followers = await authorProfile
+      .getFollowers()
+      .map(followee => ({
+        id: followee.id,
+        firstname: followee.firstname,
+        lastname: followee.lastname,
+        username: followee.username,
+        email: followee.email,
+      }));
+    fullProfile.followings = await authorProfile
+      .getFollowings()
+      .map(followee => ({
+        id: followee.id,
+        firstname: followee.firstname,
+        lastname: followee.lastname,
+        username: followee.username,
+        email: followee.email,
+      }));
+    return successResponse(
+      res,
+      200,
+      'Get profile request successful',
+      fullProfile,
+      authorProfile.author,
+    );
   } catch (error) {
     return errorResponse(res, 500, error.message);
   }

--- a/src/tests/routes/controllers/users.test.js
+++ b/src/tests/routes/controllers/users.test.js
@@ -38,10 +38,10 @@ describe('List Users functionality', () => {
       expect(res.body.message)
         .to.be.a('String')
         .to.eql('Get profile request successful');
-      expect(res.body.data.authorProfile)
-        .to.be.an('object')
-        .to.have.property('username')
-        .to.eql('gentlejane');
+      expect(res.body.data).to.be.an('object');
+      expect(res.body.data).to.have.property('publications');
+      expect(res.body.data).to.have.property('followers');
+      expect(res.body.data).to.have.property('followings');
     });
   });
 
@@ -96,7 +96,7 @@ describe('USER PROFILE', () => {
         .end((err, res) => {
           expect(res.status).to.equal(200);
           expect(res.body.message).to.equal(
-            'Your profile has been updated succesfully',
+            'Your profile has been updated successfully',
           );
           expect(res.body.data).to.be.an('object');
           done();


### PR DESCRIPTION
#### What does this PR do?
Attach user's articles and following stats to user profile

#### Description of Task to be completed?
- [x] Add users article to user profile endpoint via the user-article association as `publications`
- [x] Add users followers and followings to the user profile endpoint via the `<user>.getFollower` & `<user>.getFollowing` magic methods.

#### How should this be manually tested?
- Clone the repo,
- Run ```npm install``` to install all dependencies,
- Create a .env file using the .env.example as a guide and enter your environment variables
- Ensure you have a PostgreSQL server running on your development environment
- Run `sequelize db:create`  
- Run `sequelize db:migrate` 
- Run `sequelize db:seed:all`   
- Run `npm run start:dev`
- Hit http://localhost:3000/api/v1/users/profiles/gentlejane via your REST API client (postman or insomnia).
- You should see the response below

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?(if applicable)
#165441913

#### Screenshots
<img width="1440" alt="Screenshot 2019-04-23 at 11 59 06 AM" src="https://user-images.githubusercontent.com/31692932/56576645-dbf67880-65c0-11e9-9e31-cf0469a86d41.png">

<img width="1440" alt="Screenshot 2019-04-23 at 11 59 11 AM" src="https://user-images.githubusercontent.com/31692932/56576689-f2043900-65c0-11e9-9185-79dc6d241fa8.png">
