### PR TITLE
[bug #165956411]Add image thumbnail to article creation

### DIFF
--- a/src/db/migrations/20190403212306-create-article.js
+++ b/src/db/migrations/20190403212306-create-article.js
@@ -47,6 +47,11 @@ export default {
         type: Sequelize.TEXT,
         allowNull: false,
       },
+      imageThumbnail: {
+        type: Sequelize.TEXT,
+        field: 'image_thumbnail',
+        allowNull: true,
+      },
       subscriptionType: {
         type: Sequelize.ENUM(FREE, PREMIUM),
         field: 'subscription_type',

--- a/src/db/models/Article.js
+++ b/src/db/models/Article.js
@@ -36,6 +36,11 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.TEXT,
       allowNull: false,
     },
+    imageThumbnail: {
+      type: DataTypes.TEXT,
+      field: 'image_thumbnail',
+      allowNull: true,
+    },
     subscriptionType: {
       type: DataTypes.ENUM(FREE, PREMIUM),
       field: 'subscription_type',

--- a/src/db/seeders/20190405073146-article-seeder.js
+++ b/src/db/seeders/20190405073146-article-seeder.js
@@ -11,6 +11,8 @@ export default {
         slug: slug(`Hello Article 1-${uuidv4()}`),
         description: 'Emmanuel Daniel uses this article',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1533036618/mb0zefwbaccwnsuwretb.jpg',
         created_at: new Date(),
         updated_at: new Date(),
       },
@@ -21,6 +23,8 @@ export default {
         slug: slug(`Messi: the GOAT-${uuidv4()}`),
         description: 'Description goes here',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1531499318/mbppkzeehprspnbbcym8.png',
         created_at: new Date(),
         updated_at: new Date(),
       },
@@ -31,6 +35,8 @@ export default {
         slug: slug(`How to live long-${uuidv4()}`),
         description: 'Description goes here',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1531499267/zfzagvwapebjvr5tzxbt.svg',
         created_at: new Date(),
         updated_at: new Date(),
       },
@@ -41,6 +47,8 @@ export default {
         slug: slug(`Giving back to the community-${uuidv4()}`),
         description: 'Description goes here',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1531498302/w5pxscssyqtgft2lhuny.svg',
         created_at: new Date(),
         updated_at: new Date(),
       },
@@ -51,6 +59,8 @@ export default {
         slug: 'Hello-Article-5-3b8ab5fa-c594-4d5a-be6c-0b56888bb299',
         description: 'Dimkpa Opara uses this article to run his tests',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1531497285/wlki6g8nykxdodyd4ixq.svg',
         created_at: new Date(),
         updated_at: new Date(),
       },
@@ -61,6 +71,8 @@ export default {
         slug: slug(`Hello Article 8-${uuidv4()}`),
         description: 'Dimkpa Opara uses this article to run his tests',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1523911955/brainstorm_l87u78.png',
         created_at: new Date(),
         updated_at: new Date(),
       },
@@ -71,6 +83,8 @@ export default {
         slug: 'Hello-Article-9-5a6fab9c-5849-4be5-973c-5a371165cd5',
         description: 'Description goes here',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1514128720/mike_vobxlw.jpg',
         created_at: new Date(),
         updated_at: new Date(),
       },
@@ -81,6 +95,8 @@ export default {
         slug: slug(`Owning your learning in life-${uuidv4()}`),
         description: 'Description goes here',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1509347819/stay_connected_iru4aq.jpg',
         created_at: new Date(),
         updated_at: new Date(),
       },
@@ -91,6 +107,8 @@ export default {
         slug: slug(`Hello Article 10-${uuidv4()}`),
         description: 'Description goes here',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1504929549/sample.jpg',
         created_at: new Date(),
         updated_at: new Date(),
       },
@@ -101,6 +119,8 @@ export default {
         slug: slug(`Hello Article 11-${uuidv4()}`),
         description: 'Description goes here',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1550365575/demo/an38yitvd6gluvvhisim.jpg',
         created_at: new Date(),
         updated_at: new Date(),
       },
@@ -111,6 +131,8 @@ export default {
         slug: slug(`Hello Article 12-${uuidv4()}`),
         description: 'Description goes here',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1550758125/demo/hmbbdx0w5zpqujppfgvp.jpg',
         created_at: new Date(),
         updated_at: new Date(),
       },
@@ -121,6 +143,8 @@ export default {
         slug: slug(`Hello Article 13-${uuidv4()}`),
         description: 'Description goes here',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1531497285/wlki6g8nykxdodyd4ixq.svg',
         created_at: new Date(),
         updated_at: new Date(),
       },
@@ -131,6 +155,8 @@ export default {
         slug: slug(`Hello Article 14-${uuidv4()}`),
         description: 'Description goes here',
         body: 'Another Body',
+        image_thumbnail:
+          'https://res.cloudinary.com/nedy123/image/upload/v1517244412/stil-326695_l0bkmk.jpg',
         created_at: new Date(),
         updated_at: new Date(),
       },

--- a/src/routes/controllers/articles.controller.js
+++ b/src/routes/controllers/articles.controller.js
@@ -32,7 +32,7 @@ const { Article, User, Report, ReadingStat, Rating, Comment } = models;
  * @returns {object} article creation error/success message.
  */
 export async function createArticle(req, res) {
-  const { title, description, body, images, tags } = req.body;
+  const { title, description, body, imageThumbnail, tags } = req.body;
   if (!title || !description || !body) {
     return errorResponse(
       res,
@@ -63,6 +63,7 @@ export async function createArticle(req, res) {
       ).toLowerCase(),
       description,
       body,
+      imageThumbnail,
       readTime: timeToReadArticle,
       subscriptionType: FREE,
       status: DRAFT,


### PR DESCRIPTION
#### What does this PR do?
 Add image thumbnail to article creation

#### Description of Task to be completed?
- [x]  Add image thumbnail to article creation endpoint
- [x] update migration to allow for image thumbnail storage
- [x] update model to cater for image thumbnail
- [x] seed dummy image thumbnails

#### How should this be manually tested?
- Clone the repo,
- Run ```npm install``` to install all dependencies,
- Create a .env file using the .env.example as a guide and enter your environment variables
- Ensure you have a PostgreSQL server running on your development environment
- Run `sequelize db:create`  
- Run `sequelize db:migrate` 
- Run `sequelize db:seed:all`   
- Run `npm run start:dev`
- Hit http://localhost:3000/api/v1/articles/ via your REST API client (postman or insomnia).
- You should be able to upload an image while creating an article

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?(if applicable)
#165956411

#### Screenshots