### PR TITLE
Fix reset password bug. Implement don't send password to the client

### DIFF
--- a/src/routes/controllers/articles.controller.js
+++ b/src/routes/controllers/articles.controller.js
@@ -9,6 +9,7 @@ import {
   getArticlebyId,
   serverError,
   isValidUuid,
+  excludeProperty,
 } from '../../utils/helpers.utils';
 import { FREE, DRAFT } from '../../utils/constants';
 import { calculateTimeToReadArticle } from '../../utils/readtime.utils';
@@ -222,7 +223,8 @@ export async function likeAnArticle(req, res) {
     if (!article) return errorResponse(res, 404, 'Article does not exist');
 
     await user.addLike(article);
-    const userData = user.toJSON();
+    const userDetails = user.toJSON();
+    const userData = excludeProperty(userDetails, ['password']);
     const likes = await user.getLikes();
 
     userData.likes = likes.map(item => {
@@ -256,7 +258,8 @@ export async function unlikeAnArticle(req, res) {
     if (!article) return errorResponse(res, 404, 'Article does not exist');
 
     await user.removeLike(article);
-    const userData = user.toJSON();
+    const userDetails = user.toJSON();
+    const userData = excludeProperty(userDetails, ['password']);
     const likes = await user.getLikes();
 
     userData.likes = likes.map(item => {
@@ -338,7 +341,8 @@ export async function bookmarkArticle(req, res) {
     if (!article) return errorResponse(res, 404, 'Article does not exist');
 
     await user.addBookmarks(article);
-    const userData = user.toJSON();
+    const userDetails = user.toJSON();
+    const userData = excludeProperty(userDetails, ['password']);
     const bookmarks = await user.getBookmarks();
 
     userData.bookmarks = bookmarks.map(item => {
@@ -372,7 +376,8 @@ export async function removeBookmark(req, res) {
     if (!article) return errorResponse(res, 404, 'Article does not exist');
 
     await user.removeBookmarks(article);
-    const userData = user.toJSON();
+    const userDetails = user.toJSON();
+    const userData = excludeProperty(userDetails, ['password']);
     const bookmarks = await user.getBookmarks();
 
     userData.bookmarks = bookmarks.map(item => {

--- a/src/routes/controllers/auth.controller.js
+++ b/src/routes/controllers/auth.controller.js
@@ -6,6 +6,7 @@ import {
   successResponse,
   checkDuplicateUser,
   serverError,
+  excludeProperty,
 } from '../../utils/helpers.utils';
 import models from '../../db/models';
 import { sendMailer } from '../../config/mail-config';
@@ -157,8 +158,11 @@ export async function login(req, res) {
       id,
       email,
     });
+
+    const userJSON = user.toJSON();
+    const authenticatedUser = excludeProperty(userJSON, ['password']);
     return successResponse(res, 200, 'You have successfully logged in', {
-      user,
+      authenticatedUser,
       token,
     });
   } catch (error) {

--- a/src/routes/controllers/password.controller.js
+++ b/src/routes/controllers/password.controller.js
@@ -5,6 +5,7 @@ import models from '../../db/models';
 import {
   generateToken,
   getUserbyEmail,
+  serverError,
   errorResponse,
   successResponse,
   verifyToken,
@@ -55,7 +56,7 @@ export async function forgotPassword(req, res) {
       token,
     });
   } catch (err) {
-    return errorResponse(res, 500, 'Email could not be sent, please try again');
+    return serverError(res);
   }
 }
 
@@ -68,7 +69,7 @@ export async function forgotPassword(req, res) {
 export async function resetPassword(req, res) {
   const { token } = req.params;
   const { password } = req.body;
-  const hashedPassword = bcrypt.hash(password, 10);
+  const hashedPassword = await bcrypt.hash(password, 10);
   const user = await verifyToken(token);
   if (user === null) {
     return errorResponse(res, 400, 'Token Malformed', true);
@@ -77,7 +78,7 @@ export async function resetPassword(req, res) {
   try {
     await User.update(
       {
-        passwords: hashedPassword,
+        password: hashedPassword,
       },
       {
         where: {
@@ -87,10 +88,6 @@ export async function resetPassword(req, res) {
     );
     return successResponse(res, 200, 'Password successfully reset');
   } catch (err) {
-    return errorResponse(
-      res,
-      500,
-      'Password could not be reset, please try again',
-    );
+    return serverError(res);
   }
 }

--- a/src/tests/routes/controllers/auth.test.js
+++ b/src/tests/routes/controllers/auth.test.js
@@ -63,12 +63,12 @@ describe('User Login Feature', () => {
       expect(res.body)
         .to.have.property('message')
         .to.be.a('string');
-      expect(res.body.data).to.include.deep.keys('user', 'token');
+      expect(res.body.data).to.include.deep.keys('authenticatedUser', 'token');
       expect(res.body.data)
         .to.have.property('token')
         .to.not.eql('');
       expect(res.body.data).to.nested.include({
-        'user.email': email,
+        'authenticatedUser.email': email,
       });
     });
   });

--- a/src/tests/routes/controllers/password.test.js
+++ b/src/tests/routes/controllers/password.test.js
@@ -10,6 +10,10 @@ let resetToken;
 const userEmail = {
   email: 'jsmith@gmail.com',
 };
+const newPassword = {
+  password: '123password',
+};
+
 const fpUrl = '/api/v1/auth/users/forgot-password';
 const resetUrl = '/api/v1/auth/users/reset-password';
 describe('Forgot Password', () => {
@@ -46,7 +50,7 @@ describe('Reset Password', () => {
     chai
       .request(app)
       .patch(`${resetUrl}/${resetToken}`)
-      .send('password')
+      .send(newPassword)
       .end((err, res) => {
         expect(res.status).to.equal(200);
         expect(res.body.message).to.equal('Password successfully reset');
@@ -69,18 +73,6 @@ describe('Reset Password', () => {
   });
 
   describe('Reset Password', () => {
-    it('should return a success and status of 200 if password has been reset', done => {
-      chai
-        .request(app)
-        .patch(`${resetUrl}/${resetToken}`)
-        .send('password')
-        .end((err, res) => {
-          expect(res.status).to.equal(200);
-          expect(res.body.message).to.equal('Password successfully reset');
-          done();
-        });
-    });
-
     it('should fail if no token is provided in the request', done => {
       chai
         .request(app)

--- a/src/tests/routes/controllers/users.test.js
+++ b/src/tests/routes/controllers/users.test.js
@@ -62,7 +62,7 @@ describe('List Users functionality', () => {
 const userRequestObject = {
   username: 'janesmith',
   email: 'jsmith@gmail.com',
-  password: 'hhrtuyhgty5t678',
+  password: '123password',
 };
 
 const signinUrl = '/api/v1/auth/login';

--- a/src/tests/utils/notifications/article-notification.test.js
+++ b/src/tests/utils/notifications/article-notification.test.js
@@ -34,14 +34,14 @@ describe('Article Notification', () => {
       .post('/api/v1/auth/login')
       .send(userWithFollower)
       .end((err, res) => {
-        userIdWithFollower = res.body.data.user.id;
+        userIdWithFollower = res.body.data.authenticatedUser.id;
       });
     chai
       .request(app)
       .post('/api/v1/auth/login')
       .send(userWithoutFollower)
       .end((err, res) => {
-        userIdWithoutFollower = res.body.data.user.id;
+        userIdWithoutFollower = res.body.data.authenticatedUser.id;
         done();
       });
   });

--- a/src/utils/helpers.utils.js
+++ b/src/utils/helpers.utils.js
@@ -203,3 +203,32 @@ export const serverError = (res, statusCode = 500) =>
     message:
       'Your request could not be processed at this time. Kindly try again later.',
   });
+
+/**
+ *
+ *
+ * @param {object} obj
+ * @param {array} keys
+ * @returns {object} filteredObject
+ */
+export function pick(obj, keys) {
+  return keys
+    .map(key => (key in obj ? { [key]: obj[key] } : {}))
+    .reduce(
+      (finalObject, arrayOfObjects) =>
+        Object.assign(finalObject, arrayOfObjects),
+      {},
+    );
+}
+
+/**
+ *
+ *
+ * @param {object} obj
+ * @param {array} keys
+ * @returns {object} filteredObject
+ */
+export function excludeProperty(obj, keys) {
+  const filteredKeys = Object.keys(obj).filter(key => !keys.includes(key));
+  return pick(obj, filteredKeys);
+}


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the password bug in reset password.
It also fixes the bug of password being sent back to the client

#### Description of Task to be completed?
Correct the typo that exists in the backend with reset password.
Also stop 'password' from returning to the client

#### How should this be manually tested?
- Clone the repo
- Install dependencies with npm i
- Open Postman and post to localhost:3000/api/v1/auth/login

#### Any background context you want to provide?
The api was returning the password to the client. This PR fixes that.
The Reset Password was not updating the database. This PR fixes that

#### What are the relevant pivotal tracker stories?(if applicable)
#166181140 Fix password issues in reset password and in data being sent back to the client

#### Screenshots
![image](https://user-images.githubusercontent.com/41264503/58242329-8ab7e100-7d46-11e9-8f2a-2ad8bcc7449c.png)
