### PR TITLE
present ratings details when getting single article

### DIFF
--- a/src/routes/controllers/articles.controller.js
+++ b/src/routes/controllers/articles.controller.js
@@ -168,6 +168,11 @@ export async function getSingleArticle(req, res) {
           attributes: ['firstName', 'lastName', 'username', 'image'],
         },
         {
+          model: Rating,
+          as: 'ratings',
+          attributes: ['id', 'userId', 'articleId', 'rating'],
+        },
+        {
           model: Comment,
           as: 'comments',
           include: [
@@ -193,7 +198,13 @@ export async function getSingleArticle(req, res) {
     if (article) {
       // record the user reading the article
       const currentArticle = article.toJSON();
-      currentArticle.likes = await article.getLikes();
+      currentArticle.likes = await article.getLikes().map(like => ({
+        id: like.id,
+        firstName: like.firstName,
+        lastName: like.lastName,
+        username: like.username,
+        email: like.email,
+      }));
 
       await recordARead(article.id, requestUser);
       return successResponse(res, 200, '', currentArticle);


### PR DESCRIPTION
#### What does this PR do?
It includes article ratings when the article is requested

#### Description of Task to be completed?
A bug fix that includes Ratings in the Get Single Article feature

#### How should this be manually tested?
- Clone the repo
- Run npm install
- Open postman and do a get request to http://localhost:3000/api/v1/articles/141f4f05-7d81-4593-ab54-e256c1006210

#### Any background context you want to provide?
When an article is gotten on the frontend, the ratings data of that article should be available with the article

#### What are the relevant pivotal tracker stories?(if applicable)
#166254926 Include Ratings so that it comes with Article

#### Screenshots
![image](https://user-images.githubusercontent.com/41264503/58372618-319fa700-7f18-11e9-85f3-8978604f3dfa.png)
